### PR TITLE
feat(rust): use `wide` output only for list operations

### DIFF
--- a/codegenerator/rust_cli.py
+++ b/codegenerator/rust_cli.py
@@ -25,7 +25,15 @@ from codegenerator.common import BaseCombinedType
 from codegenerator.common import BaseCompoundType
 
 
-BASIC_FIELDS = ["id", "name", "created_at", "updated_at"]
+BASIC_FIELDS = [
+    "id",
+    "name",
+    "created_at",
+    "updated_at",
+    "uuid",
+    "state",
+    "status",
+]
 
 
 class BooleanFlag(common_rust.Boolean):
@@ -215,7 +223,11 @@ class StructFieldResponse(common_rust.StructField):
         return f"#[serde({', '.join(sorted(macros))})]"
 
     def get_structable_macros(
-        self, struct: "StructResponse", service_name: str, resource_name: str
+        self,
+        struct: "StructResponse",
+        service_name: str,
+        resource_name: str,
+        operation_type: str,
     ):
         macros = set([])
         if self.is_optional:
@@ -228,17 +240,20 @@ class StructFieldResponse(common_rust.StructField):
         ).lower()
         # Check the known alias of the field by FQAN
         alias = common.FQAN_ALIAS_MAP.get(fqan)
-        if (
-            "id" in struct.fields.keys()
-            and not (self.local_name in BASIC_FIELDS or alias in BASIC_FIELDS)
-        ) or (
-            "id" not in struct.fields.keys()
-            and (self.local_name not in list(struct.fields.keys())[-10:])
-        ):
-            # Only add "wide" flag if field is not in the basic fields AND
-            # there is at least "id" field existing in the struct OR the
-            # field is not in the first 10
-            macros.add("wide")
+        if operation_type == "list":
+            if (
+                "id" in struct.fields.keys()
+                and not (
+                    self.local_name in BASIC_FIELDS or alias in BASIC_FIELDS
+                )
+            ) or (
+                "id" not in struct.fields.keys()
+                and (self.local_name not in list(struct.fields.keys())[-10:])
+            ):
+                # Only add "wide" flag if field is not in the basic fields AND
+                # there is at least "id" field existing in the struct OR the
+                # field is not in the first 10
+                macros.add("wide")
         return f"#[structable({', '.join(sorted(macros))})]"
 
 

--- a/codegenerator/templates/rust_cli/response_struct.j2
+++ b/codegenerator/templates/rust_cli/response_struct.j2
@@ -8,12 +8,19 @@
       {%- for k, v in data_type.fields.items() %}
         {{ macros.docstring(v.description, indent=4) }}
         {{ v.serde_macros }}
-        {{ v.get_structable_macros(data_type, sdk_service_name, resource_name) }}
+        {{ v.get_structable_macros(data_type, sdk_service_name, resource_name, operation_type) }}
         {{ v.local_name }}: {{ v.type_hint }},
       {%- endfor %}
 
     }
-  {%- elif data_type.tuple_fields is defined %}
+  {%- else %}
+    {#- No response data at all #}
+    /// {{ target_class_name }} response representation
+    #[derive(Deserialize, Debug, Clone, Serialize, StructTable)]
+    pub struct ResponseData {}
+  {%- endif %}
+
+{%- elif data_type.__class__.__name__ == "TupleStruct" %}
     {#- tuple struct requires custom implementation of StructTable #}
     /// {{ target_class_name }} response representation
     #[derive(Deserialize, Debug, Clone, Serialize)]
@@ -43,13 +50,6 @@
             (headers, res)
         }
     }
-  {%- else %}
-    {#- No response data at all #}
-    /// {{ target_class_name }} response representation
-    #[derive(Deserialize, Debug, Clone, Serialize, StructTable)]
-    pub struct ResponseData {}
-  {%- endif %}
-
 {%- elif data_type.__class__.__name__ == "HashMapResponse" %}
     #[derive(Deserialize, Debug, Clone, Serialize)]
     pub struct ResponseData(HashMap<String, serde_json::Value>);

--- a/metadata/block-storage_metadata.yaml
+++ b/metadata/block-storage_metadata.yaml
@@ -1320,7 +1320,7 @@ resources:
     api_version: v3
     operations:
       list_detailed:
-        operation_id: volume-transfers/detail:get
+        operation_id: os-volume-transfer/detail:get
         operation_type: list
         targets:
           rust-sdk:
@@ -1329,13 +1329,13 @@ resources:
             module_name: list
             sdk_mod_name: list_detailed
       list:
-        operation_id: volume-transfers:get
+        operation_id: os-volume-transfer:get
         operation_type: list
         targets:
           rust-sdk:
             module_name: list
       create:
-        operation_id: volume-transfers:post
+        operation_id: os-volume-transfer/id/accept:post
         operation_type: create
         targets:
           rust-sdk:
@@ -1353,7 +1353,7 @@ resources:
             module_name: accept
             sdk_mod_name: accept
       show:
-        operation_id: volume-transfers/id:get
+        operation_id: os-volume-transfer/id:get
         operation_type: show
         targets:
           rust-sdk:
@@ -1362,7 +1362,7 @@ resources:
             module_name: show
             sdk_mod_name: get
       delete:
-        operation_id: volume-transfers/id:delete
+        operation_id: os-volume-transfer/id:delete
         operation_type: delete
         targets:
           rust-sdk:
@@ -1450,7 +1450,7 @@ resources:
           rust-cli:
             module_name: delete
             sdk_mod_name: delete
-  block-storage.os_availability_zone:
+  block-storage.availability_zone:
     spec_file: wrk/openapi_specs/block-storage/v3.yaml
     api_version: v3
     operations:
@@ -1587,7 +1587,7 @@ resources:
           rust-cli:
             module_name: create
             sdk_mod_name: create
-  block-storage.os_host:
+  block-storage.host:
     spec_file: wrk/openapi_specs/block-storage/v3.yaml
     api_version: v3
     operations:
@@ -1741,7 +1741,7 @@ resources:
           rust-cli:
             module_name: delete_keys
             sdk_mod_name: delete_keys
-  block-storage.os_quota_class_set:
+  block-storage.quota_class_set:
     spec_file: wrk/openapi_specs/block-storage/v3.yaml
     api_version: v3
     operations:
@@ -1763,7 +1763,7 @@ resources:
           rust-cli:
             module_name: set
             sdk_mod_name: set
-  block-storage.os_quota_set/default:
+  block-storage.quota_set/default:
     spec_file: wrk/openapi_specs/block-storage/v3.yaml
     api_version: v3
     operations:
@@ -1776,7 +1776,7 @@ resources:
           rust-cli:
             module_name: get
             sdk_mod_name: get
-  block-storage.os_quota_set:
+  block-storage.quota_set:
     spec_file: wrk/openapi_specs/block-storage/v3.yaml
     api_version: v3
     operations:
@@ -1820,7 +1820,7 @@ resources:
           rust-cli:
             module_name: get
             sdk_mod_name: get
-  block-storage.os_service:
+  block-storage.service:
     spec_file: wrk/openapi_specs/block-storage/v3.yaml
     api_version: v3
     operations:
@@ -1842,7 +1842,7 @@ resources:
           rust-cli:
             module_name: set
             sdk_mod_name: set
-  block-storage.os_snapshot_manage:
+  block-storage.snapshot_manage:
     spec_file: wrk/openapi_specs/block-storage/v3.yaml
     api_version: v3
     operations:
@@ -1944,7 +1944,7 @@ resources:
           rust-cli:
             module_name: show
             sdk_mod_name: get
-  block-storage.os_volume_manage:
+  block-storage.volume_manage:
     spec_file: wrk/openapi_specs/block-storage/v3.yaml
     api_version: v3
     operations:
@@ -1975,66 +1975,7 @@ resources:
           rust-cli:
             module_name: create
             sdk_mod_name: create
-  block-storage.os_volume_transfer:
-    spec_file: wrk/openapi_specs/block-storage/v3.yaml
-    api_version: v3
-    operations:
-      list_detailed:
-        operation_id: os-volume-transfer/detail:get
-        operation_type: list
-        targets:
-          rust-sdk:
-            module_name: list_detailed
-          rust-cli:
-            module_name: list
-            sdk_mod_name: list_detailed
-      list:
-        operation_id: os-volume-transfer:get
-        operation_type: list
-        targets:
-          rust-sdk:
-            module_name: list
-      create:
-        operation_id: os-volume-transfer:post
-        operation_type: create
-        targets:
-          rust-sdk:
-            module_name: create
-          rust-cli:
-            module_name: create
-            sdk_mod_name: create
-      show:
-        operation_id: os-volume-transfer/id:get
-        operation_type: show
-        targets:
-          rust-sdk:
-            module_name: get
-          rust-cli:
-            module_name: show
-            sdk_mod_name: get
-      delete:
-        operation_id: os-volume-transfer/id:delete
-        operation_type: delete
-        targets:
-          rust-sdk:
-            module_name: delete
-          rust-cli:
-            module_name: delete
-            sdk_mod_name: delete
-  block-storage.os_volume_transfer/accept:
-    spec_file: wrk/openapi_specs/block-storage/v3.yaml
-    api_version: v3
-    operations:
-      create:
-        operation_id: os-volume-transfer/id/accept:post
-        operation_type: create
-        targets:
-          rust-sdk:
-            module_name: create
-          rust-cli:
-            module_name: create
-            sdk_mod_name: create
-  block-storage.type/os_volume_type_access:
+  block-storage.type/volume_type_access:
     spec_file: wrk/openapi_specs/block-storage/v3.yaml
     api_version: v3
     operations:


### PR DESCRIPTION
forcing user to use `-o wide` for every non list operation makes no
sense. Modify generator to only add `wide` macros in the list
operations.
