### PR TITLE
fix: properly set serde(flatten) for extensible structs

### DIFF
--- a/codegenerator/templates/rust_cli/impl.rs.j2
+++ b/codegenerator/templates/rust_cli/impl.rs.j2
@@ -92,11 +92,19 @@ enum {{ type.name }} {
 #[group(required={{ type.is_required | lower }}, multiple={{ "true" if type.__class__.__name__ != "EnumGroupStruct" else "false" }})]
 {%- endif %}
 struct {{ type.name }} {
+ {%- if type["is_group"] is defined and type.is_group %}
+  {%- for (_, field) in type.fields | dictsort %}
+    {{ macros.docstring(field.description, indent=4) }}
+    {{ field.clap_macros_ext(is_group=type.is_group) }}
+    {{ field.local_name }}: {{ field.type_hint }},
+  {%- endfor %}
+ {%- else %}
   {%- for field in type.fields.values() %}
     {{ macros.docstring(field.description, indent=4) }}
     {{ field.clap_macros_ext(is_group=type.is_group) }}
     {{ field.local_name }}: {{ field.type_hint }},
   {%- endfor %}
+ {%- endif %}
 }
 {%- endif %}
 {% endfor %}

--- a/codegenerator/templates/rust_sdk/subtypes.j2
+++ b/codegenerator/templates/rust_sdk/subtypes.j2
@@ -36,6 +36,7 @@ pub {{ subtype.base_type }} {{ subtype.name }}{{ ("<" + ",".join(subtype.lifetim
   {%- if subtype.base_type == "struct" and subtype.additional_fields_type %}
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, {{ subtype.additional_fields_type.type_hint }}>,
   {%- endif %}
 }


### PR DESCRIPTION
in the rust sdk set the `serde(flatten)` macro on the _properties of
structs supporting additional attributes.