### PR TITLE
feat: format comments as markdown for rendering

### DIFF
--- a/codegenerator/base.py
+++ b/codegenerator/base.py
@@ -15,6 +15,7 @@ import abc
 import logging
 from pathlib import Path
 import subprocess
+import mdformat as md
 
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
@@ -24,11 +25,19 @@ from jinja2 import StrictUndefined
 
 class BaseGenerator:
     def __init__(self):
+        # Lower debug level of mdformat
+        logging.getLogger("markdown_it").setLevel(logging.INFO)
+
+        def wrap_markdown(input: str, width: int = 79) -> str:
+            """Apply mardownify to wrap the markdown"""
+            return md.text(input, options={"wrap": width})
+
         self.env = Environment(
             loader=FileSystemLoader("codegenerator/templates"),
             autoescape=select_autoescape(),
             undefined=StrictUndefined,
         )
+        self.env.filters["wrap_markdown"] = wrap_markdown
 
     def get_parser(self, parser):
         return parser

--- a/codegenerator/openapi/utils.py
+++ b/codegenerator/openapi/utils.py
@@ -530,4 +530,4 @@ def _get_schema_candidates(
 
 
 def get_sanitized_description(descr: str) -> LiteralScalarString:
-    return LiteralScalarString(md(descr))
+    return LiteralScalarString(md(descr, escape_underscores=False))

--- a/codegenerator/templates/rust_cli/response_struct.j2
+++ b/codegenerator/templates/rust_cli/response_struct.j2
@@ -85,7 +85,7 @@
 
 {%- for subtype in response_type_manager.get_subtypes() %}
 {%- if subtype["fields"] is defined %}
-/// {{ subtype.base_type }} response type
+/// `{{ subtype.base_type }}` response type
 #[derive(Default)]
 #[derive(Clone)]
 #[derive(Deserialize, Serialize)]
@@ -123,7 +123,7 @@ impl fmt::Display for {{ subtype.name }} {
 }
 
 {%- elif subtype.base_type == "vec" %}
-/// Vector of {{ subtype.item_type.type_hint}} response type
+/// Vector of `{{ subtype.item_type.type_hint}}` response type
 #[derive(Default)]
 #[derive(Clone)]
 #[derive(Deserialize, Serialize)]
@@ -143,7 +143,7 @@ impl fmt::Display for Vec{{ subtype.item_type.type_hint }} {
 }
 
 {%- elif subtype.base_type == "dict"  %}
-/// HashMap of {{ subtype.value_type.type_hint }} response type
+/// HashMap of `{{ subtype.value_type.type_hint }}` response type
 #[derive(Default)]
 #[derive(Clone)]
 #[derive(Deserialize, Serialize)]

--- a/codegenerator/templates/rust_macros.j2
+++ b/codegenerator/templates/rust_macros.j2
@@ -1,13 +1,13 @@
 {%- macro mod_docstring(v) %}
 {%- if v %}
-//! {{ v | wordwrap(width=75) | replace('\n', '\n//! ') }}
+//! {{ v | wrap_markdown(75) | replace('\n', '\n//! ') }}
 {%- endif %}
 {%- endmacro %}
 
 {%- macro docstring(doc, indent=0) %}
 {#- docstring for an element #}
 {%- if doc %}
-{{ (' ' * indent) }}/// {{ doc | trim("\n") | wordwrap(width=79-indent-4) | replace('\n', '\n' + (' ' * indent) + '/// ') }}
+{{ (' ' * indent) }}/// {{ doc | trim("\n") | wrap_markdown(79-indent-4) | replace('\n', '\n' + (' ' * indent) + '/// ') }}
 {%- endif %}
 {%- endmacro %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,10 @@ sphinx
 ruamel.yaml
 jsonschema
 bs4[spec]
+# convert html into markdown
 markdownify[spec]
+# wrap markdown when rendering
+mdformat # MIT
 wsgi_intercept[spec]
 oslotest[spec]
 nova[spec]


### PR DESCRIPTION
simple wordwrap in the rendering causes formatting to be broken. Add
custom jinja filter `wrap_markdown` based on the `mdformat` library.