### PR TITLE
feat: extend identity.role coverage

### DIFF
--- a/codegenerator/metadata.py
+++ b/codegenerator/metadata.py
@@ -702,6 +702,14 @@ def post_process_compute_operation(
 def post_process_identity_operation(
     resource_name: str, operation_name: str, operation
 ):
+    if resource_name == "role/imply":
+        if operation_name == "list":
+            operation.targets["rust-cli"].response_key = "role_inference"
+            operation.targets["rust-sdk"].response_key = "role_inference"
+    if resource_name == "role_inference":
+        if operation_name == "list":
+            operation.targets["rust-cli"].response_key = "role_inferences"
+            operation.targets["rust-sdk"].response_key = "role_inferences"
     return operation
 
 

--- a/codegenerator/openapi/cinder_schemas.py
+++ b/codegenerator/openapi/cinder_schemas.py
@@ -23,7 +23,7 @@ LINK_SCHEMA: dict[str, Any] = {
     "type": "object",
     "description": "Links to the resources in question. See [API Guide / Links and References](https://docs.openstack.org/api-guide/compute/links_and_references.html) for more info.",
     "properties": {
-        "href": {"type": "string", "format": "url"},
+        "href": {"type": "string", "format": "uri"},
         "rel": {"type": "string"},
     },
 }

--- a/codegenerator/openapi/keystone_schemas/auth.py
+++ b/codegenerator/openapi/keystone_schemas/auth.py
@@ -363,7 +363,7 @@ AUTH_CATALOG_SCHEMA: dict[str, Any] = {
                                 },
                                 "url": {
                                     "type": "string",
-                                    "format": "url",
+                                    "format": "uri",
                                     "description": "The endpoint url",
                                 },
                             },

--- a/codegenerator/openapi/keystone_schemas/common.py
+++ b/codegenerator/openapi/keystone_schemas/common.py
@@ -21,7 +21,7 @@ LINK_SCHEMA: dict[str, Any] = {
     "type": "object",
     "description": "Links to the resources in question. See [API Guide / Links and References](https://docs.openstack.org/api-guide/compute/links_and_references.html) for more info.",
     "properties": {
-        "href": {"type": "string", "format": "url"},
+        "href": {"type": "string", "format": "uri"},
         "rel": {"type": "string"},
     },
 }

--- a/codegenerator/openapi/keystone_schemas/domain.py
+++ b/codegenerator/openapi/keystone_schemas/domain.py
@@ -39,7 +39,7 @@ DOMAIN_CONFIG_GROUP_LDAP = {
     "properties": {
         "url": {
             "type": "string",
-            "format": "url",
+            "format": "uri",
             "description": "The LDAP URL.",
         },
         "user_tree_dn": {

--- a/codegenerator/openapi/keystone_schemas/endpoint.py
+++ b/codegenerator/openapi/keystone_schemas/endpoint.py
@@ -36,7 +36,7 @@ ENDPOINT_SCHEMA: dict[str, Any] = {
         },
         "region": {
             "type": "string",
-            "description": "The geographic location of the service ",
+            "description": "The geographic location of the service endpoint.",
             "x-openstack": {"max-ver": "3.2"},
         },
         "region_id": {
@@ -52,7 +52,7 @@ ENDPOINT_SCHEMA: dict[str, Any] = {
         },
         "url": {
             "type": "string",
-            "format": "url",
+            "format": "uri",
             "description": "The endpoint URL.",
         },
     },

--- a/codegenerator/openapi/keystone_schemas/region.py
+++ b/codegenerator/openapi/keystone_schemas/region.py
@@ -25,12 +25,12 @@ REGION_SCHEMA: dict[str, Any] = {
         "id": {
             "type": "string",
             "format": "uuid",
-            "description": "The ID for the ",
+            "description": "The ID for the region.",
         },
         "parent_id": {
             "type": "string",
             "format": "uuid",
-            "description": "To make this region a child of another region, set this parameter to the ID of the parent ",
+            "description": "To make this region a child of another region, set this parameter to the ID of the parent region.",
         },
     },
 }

--- a/codegenerator/openapi/nova_schemas.py
+++ b/codegenerator/openapi/nova_schemas.py
@@ -25,7 +25,7 @@ LINK_SCHEMA: dict[str, Any] = {
     "type": "object",
     "description": "Links to the resources in question. See [API Guide / Links and References](https://docs.openstack.org/api-guide/compute/links_and_references.html) for more info.",
     "properties": {
-        "href": {"type": "string", "format": "url"},
+        "href": {"type": "string", "format": "uri"},
         "rel": {"type": "string"},
     },
 }
@@ -477,7 +477,7 @@ REMOTE_CONSOLE_SCHEMA: dict[str, Any] = {
                 },
                 "url": {
                     "type": "string",
-                    "format": "url",
+                    "format": "uri",
                     "description": "The URL is used to connect the console.",
                 },
             },

--- a/metadata/identity_metadata.yaml
+++ b/metadata/identity_metadata.yaml
@@ -2294,15 +2294,17 @@ resources:
         targets:
           rust-sdk:
             module_name: head
-      get:
+      list:
         operation_id: role_inferences:get
-        operation_type: get
+        operation_type: list
         targets:
           rust-sdk:
-            module_name: get
+            module_name: list
+            response_key: role_inferences
           rust-cli:
-            module_name: get
-            sdk_mod_name: get
+            module_name: list
+            sdk_mod_name: list
+            response_key: role_inferences
   identity.role:
     spec_file: wrk/openapi_specs/identity/v3.yaml
     api_version: v3
@@ -2387,9 +2389,11 @@ resources:
         targets:
           rust-sdk:
             module_name: list
+            response_key: role_inference
           rust-cli:
             module_name: list
             sdk_mod_name: list
+            response_key: role_inference
       show:
         operation_id: roles/prior_role_id/implies/implied_role_id:get
         operation_type: show

--- a/tools/generate_rust_identity.sh
+++ b/tools/generate_rust_identity.sh
@@ -12,6 +12,8 @@ NET_RESOURCES=(
   "endpoint"
   "region"
   "role_assignment"
+  "role_inference"
+  "role"
 )
 
 openstack-codegenerator --work-dir ${WRK_DIR} --target rust-sdk --metadata ${METADATA}/identity_metadata.yaml --service identity


### PR DESCRIPTION
- **chore: move federation schemas into dedicated mod**
- **chore: move rest or role schemas to separate mod**
- **chore: move appcreds schemas to separate mod**
- **chore: move auth schemas to separate module**
- **chore: move domain schemas to separate module**
- **chore: move user schemas to separate module**
- **chore: move endpoint schemas to separate module**
- **chore: move service schemas to separate module**
- **chore: move region schemas to separate module**
- **chore: move project schemas to separate module**
- **chore: move group schemas to separate module**
- **feat: extend identity.role coverage**
